### PR TITLE
[fix] search box fixes

### DIFF
--- a/src/lib/SearchBox.svelte
+++ b/src/lib/SearchBox.svelte
@@ -63,7 +63,8 @@
   position: absolute;
   top: 10px;
   right: 10px;
-  width: 400px;
+  width: calc(100vw - 60px);
+  max-width: 400px;
 }
 
 :global(.search-box input) {

--- a/src/lib/SearchBox.svelte
+++ b/src/lib/SearchBox.svelte
@@ -20,11 +20,11 @@
 
   function handleKeyDown(event) {
     if (event.key === "Enter"  ||  event.keyCode === 13) {
-      for (const item of places) {
-        if (query == item.name) {
-          results = [];
-          onSelect(item);
-        }
+      const myresults = fuse.search(query);
+      if (myresults.length != 0) {
+        query = myresults[0].item.name;
+        results = [];
+        onSelect(myresults[0].item);
       }
     }
   }

--- a/src/lib/SearchBox.svelte
+++ b/src/lib/SearchBox.svelte
@@ -13,6 +13,8 @@
   const places = [...nd_zipcodes, ...nd_places];
   const fuse = new Fuse(places, { keys: ["name"] });
 
+  const MAX_SEARCH_RESULTS = 5;
+
   let searchBox;
   let query = "";
   let results = [];
@@ -20,7 +22,7 @@
 
   function handleKeyDown(event) {
     if (event.key === "Enter"  ||  event.keyCode === 13) {
-      const myresults = fuse.search(query);
+      const myresults = fuse.search(query, { limit: 1 });
       if (myresults.length != 0) {
         query = myresults[0].item.name;
         results = [];
@@ -31,7 +33,7 @@
 
   function handleInput(event) {
     query = event.target.value;
-    results = fuse.search(query).map(result => result.item);
+    results = fuse.search(query, { limit: MAX_SEARCH_RESULTS }).map(result => result.item);
   }
 
   // clicks outside of the whole search region should hide the matches
@@ -50,7 +52,7 @@
   <Menu class="search-results">
     {#if results.length != 0}
     <List>
-      {#each results.slice(0, 5) as result}
+      {#each results.slice(0, MAX_SEARCH_RESULTS) as result}
         <Item onSMUIAction={() => {results = []; onSelect(result);}}><Text>{result.name}</Text></Item>
       {/each}
     </List>

--- a/src/lib/SearchBox.svelte
+++ b/src/lib/SearchBox.svelte
@@ -51,7 +51,7 @@
     {#if results.length != 0}
     <List>
       {#each results.slice(0, 5) as result}
-        <Item onSMUIAction={() => {onSelect(result);}}><Text>{result.name}</Text></Item>
+        <Item onSMUIAction={() => {results = []; onSelect(result);}}><Text>{result.name}</Text></Item>
       {/each}
     </List>
     {/if}


### PR DESCRIPTION
Part of #12.

* Search results now disappear when you select one, no matter how you do that (typing an exact match and pressing enter, tabbing to a result and pressing enter, or clicking on a result with the mouse).
* Typing a word followed by pressing enter no longer requires the typed string to be an exact match; it uses the same fuzzy search as the drop-down menu.
* Probably tiny performance improvement: pass `{ limit: MAX_SEARCH_RESULTS }` to `fuse.search` since I'm not going to display more than `MAX_SEARCH_RESULTS` anyway.
* The search bar width is now a `max-width` with smaller widths calculated from the screen size with enough clearance for the other search tools. Checked with https://screenfly.org/.

### Motorola RAZR V3m (176×220)

![image](https://github.com/user-attachments/assets/314314e9-2138-4df5-b7a8-d2da5138b5a2)

### Motorola RAZR V8 (240×320)

![image](https://github.com/user-attachments/assets/a85d20cf-5692-4efa-9f19-09b5e44a2b4a)

### BlackBerry 8300 (320×240)

![image](https://github.com/user-attachments/assets/d3016c8e-64cb-4e7e-980a-b0639095f1b9)

### Apple iPhone 3/4 (320×480)

![image](https://github.com/user-attachments/assets/7d7aeb21-ba20-42d8-ae9d-013158c83ba2)

### Samsung Galaxy S2 (320×533)

![image](https://github.com/user-attachments/assets/51d9c5b4-8566-47eb-b4e8-5cb70a88bcff)

### Apple iPhone 5 (320×568)

![image](https://github.com/user-attachments/assets/79fe3c92-7216-4297-8094-a10fa31f09c2)

### LG G3-5 (360×640)

![image](https://github.com/user-attachments/assets/3c19c67e-a268-4abc-9c76-725d8cb06ef4)

### Samsung Galaxy S3-7 (360×640)

![image](https://github.com/user-attachments/assets/aa006a97-8324-4548-8000-38f5e534d3b1)

### Apple iPhone 6/7 (375×667)

![image](https://github.com/user-attachments/assets/0279739b-cd61-44e9-b2e8-5825196359c2)

### Apple iPhone 6/7 Plus (414×736)

![image](https://github.com/user-attachments/assets/b2e9455b-e337-4c3e-895e-e8561f22fd49)