### PR TITLE
more address box fixes

### DIFF
--- a/src/lib/SearchBox.svelte
+++ b/src/lib/SearchBox.svelte
@@ -76,6 +76,7 @@
   /* match the style in the Menu/List */
   font-size: 16px;
   color: rgba(0, 0, 0, 0.87);
+  background-color: white;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 16px;

--- a/src/lib/SearchBox.svelte
+++ b/src/lib/SearchBox.svelte
@@ -53,7 +53,7 @@
     {#if results.length != 0}
     <List>
       {#each results.slice(0, MAX_SEARCH_RESULTS) as result}
-        <Item onSMUIAction={() => {results = []; onSelect(result);}}><Text>{result.name}</Text></Item>
+        <Item onSMUIAction={() => {query = result.name; results = []; onSelect(result);}}><Text>{result.name}</Text></Item>
       {/each}
     </List>
     {/if}


### PR DESCRIPTION
I finally understand why the colors were different on mobile: my phone is in dark mode! Now the search box and address popup are both insensitive to dark/light mode, since most of the visual contrast is set by the dark satellite image, not the UI elements.